### PR TITLE
Print output from Ex commands

### DIFF
--- a/lua/telescope-menu/actions.lua
+++ b/lua/telescope-menu/actions.lua
@@ -1,7 +1,10 @@
 local M = {}
 
 M.vim_command = function(entry, _)
-  vim.api.nvim_exec(entry.value, true)
+  local output = vim.api.nvim_exec(entry.value, true)
+  if output ~= nil then
+    print(output)
+  end
 end
 
 M.lua_function = function(entry, _)


### PR DESCRIPTION
Print output from Ex commands, this makes the behavior equivalent wit…

# Description

Some commands are meant to print messages, came across this issue while trying to use Slimv command to describe a symbol under cursor:

https://github.com/kovisoft/slimv/blob/08f7dba91c3ecd0a62a852eca92258c7ceac4f0a/ftplugin/slimv.vim#L3772

Which I exec like: `:call SlimvCommandUsePackage('python swank_describe_symbol("defpackage")' )`

You can test this with a simple `:echo "hi"` command, before the change nothing happens, after the change you can find the `hi` message with `:messages`

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
