### PR TITLE
vim.api.nvim_exec is deprecated. replace it with vim.api.nvim_exec2()

### DIFF
--- a/lua/telescope-menu/actions.lua
+++ b/lua/telescope-menu/actions.lua
@@ -1,9 +1,11 @@
 local M = {}
 
 M.vim_command = function(entry, _)
-  local output = vim.api.nvim_exec(entry.value, true)
-  if output ~= nil then
-    print(output)
+  local result = vim.api.nvim_exec2(entry.value, {
+    output = true,
+  })
+  if result.output ~= nil then
+    print(result.output)
   end
 end
 


### PR DESCRIPTION
# Description

https://neovim.io/doc/user/deprecated.html#nvim_exec()

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
